### PR TITLE
Export envkeys to running application

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -25,12 +25,12 @@ if [ -f $ENV_DIR/ENVKEY ]; then
   echo $(./envkey-source) > $BP_DIR/export
   echo "EnvKey variables exported to subsequent buildpacks" | indent
   mkdir $BUILD_DIR/.profile.d
-  cat << EOM
+  cat > $BUILD_DIR/.profile.d/envkey.sh << EOF
 export -p > ./runtime-env.sh
 $(cat $BP_DIR/export)
 . ./runtime-env.sh
 rm runtime-env.sh
-EOM > $BUILD_DIR/.profile.d/envkey.sh
+EOF
   echo "EnvKey variables exported to running application via .profile.d/envkey.sh" | indent
 else
   echo "ENVKEY config var not set" | indent

--- a/bin/compile
+++ b/bin/compile
@@ -25,7 +25,12 @@ if [ -f $ENV_DIR/ENVKEY ]; then
   echo $(./envkey-source) > $BP_DIR/export
   echo "EnvKey variables exported to subsequent buildpacks" | indent
   mkdir $BUILD_DIR/.profile.d
-  cp $BP_DIR/export $BUILD_DIR/.profile.d/envkey.sh
+  cat << EOM
+export -p > ./runtime-env.sh
+$(cat $BP_DIR/export)
+. ./runtime-env.sh
+rm runtime-env.sh
+EOM > $BUILD_DIR/.profile.d/envkey.sh
   echo "EnvKey variables exported to running application via .profile.d/envkey.sh" | indent
 else
   echo "ENVKEY config var not set" | indent

--- a/bin/compile
+++ b/bin/compile
@@ -7,6 +7,7 @@ indent() {
 echo "-----> Attempting to load, decrypt, and export EnvKey variables"
 
 BP_DIR=$(cd $(dirname ${0:-}); cd ..; pwd)
+BUILD_DIR=${1:-}
 ENV_DIR=${3:-}
 
 if [ -f $ENV_DIR/ENVKEY ]; then
@@ -22,7 +23,9 @@ if [ -f $ENV_DIR/ENVKEY ]; then
   echo "ENVKEY config var is set" | indent
   export "ENVKEY=$(cat $ENV_DIR/ENVKEY)"
   echo $(./envkey-source) > $BP_DIR/export
-  echo "EnvKey variables exported" | indent
+  echo "EnvKey variables exported to subsequent buildpacks" | indent
+  echo $(./envkey-source) > $BUILD_DIR/.profile.d/envkey.sh
+  echo "EnvKey variables exported to running application via .profile.d/envkey.sh" | indent
 else
   echo "ENVKEY config var not set" | indent
   exit 1

--- a/bin/compile
+++ b/bin/compile
@@ -25,7 +25,7 @@ if [ -f $ENV_DIR/ENVKEY ]; then
   echo $(./envkey-source) > $BP_DIR/export
   echo "EnvKey variables exported to subsequent buildpacks" | indent
   mkdir $BUILD_DIR/.profile.d
-  echo $(./envkey-source) > $BUILD_DIR/.profile.d/envkey.sh
+  cp $BP_DIR/export $BUILD_DIR/.profile.d/envkey.sh
   echo "EnvKey variables exported to running application via .profile.d/envkey.sh" | indent
 else
   echo "ENVKEY config var not set" | indent

--- a/bin/compile
+++ b/bin/compile
@@ -26,10 +26,10 @@ if [ -f $ENV_DIR/ENVKEY ]; then
   echo "EnvKey variables exported to subsequent buildpacks" | indent
   mkdir $BUILD_DIR/.profile.d
   cat > $BUILD_DIR/.profile.d/envkey.sh << EOF
-export -p > ./runtime-env.sh
+export -p > ./envkey-heroku-runtime-env.sh
 $(cat $BP_DIR/export)
-. ./runtime-env.sh
-rm runtime-env.sh
+. ./envkey-heroku-runtime-env.sh
+rm envkey-heroku-runtime-env.sh
 EOF
   echo "EnvKey variables exported to running application via .profile.d/envkey.sh" | indent
 else

--- a/bin/compile
+++ b/bin/compile
@@ -24,6 +24,7 @@ if [ -f $ENV_DIR/ENVKEY ]; then
   export "ENVKEY=$(cat $ENV_DIR/ENVKEY)"
   echo $(./envkey-source) > $BP_DIR/export
   echo "EnvKey variables exported to subsequent buildpacks" | indent
+  mkdir $BUILD_DIR/.profile.d
   echo $(./envkey-source) > $BUILD_DIR/.profile.d/envkey.sh
   echo "EnvKey variables exported to running application via .profile.d/envkey.sh" | indent
 else


### PR DESCRIPTION
Right now the buildpack only allows envkey to be used in subsequent buildpacks. Here we allow the running application to access the envkeys as well using `.profile.d` scripts. 
https://devcenter.heroku.com/articles/buildpack-api#profile-d-scripts

In particular, the env vars used will be compiled and packaged into the application slug (https://devcenter.heroku.com/articles/buildpack-api#bin-compile), so any kind of rollback would actually also rollback the env vars to the state used in that particular revision. This is definitely desirable, however it has the side effect of overriding the runtime variables passed down through Heroku config. Ideally we should preserve those set at runtime. 

TODO: 
- [x] Evaluate if env key vars should override heroku config vars
- [x] If not, implement non-overriding env key exporting for Heroku