### PR TITLE
Fix `PATH`

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -52,7 +52,7 @@ export -p > ./envkey-runtime-env.sh
 $(cat $BP_DIR/export)
 . ./envkey-runtime-env.sh
 rm envkey-runtime-env.sh
-export PATH=$PATH:$HOME/vendor/envkey/bin
+export PATH=\$PATH:\$HOME/vendor/envkey/bin
 EOF
   echo "EnvKey variables exported to running application via .profile.d/envkey.sh" | indent
   echo "envkey-source executable is available for use" | indent


### PR DESCRIPTION
This updates to keep the variables as variables - and not replace them - until it runs - getting the current “PATH”

Previously,  it was putting in the `$PATH` as it was at build time and anything else that was adding itself to path was getting lost..since it wasn’t using the path as it is when it runs

