### PR TITLE
Force envkey.sh script to run before the rest of the profile.d scripts

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -25,7 +25,7 @@ if [ -f $ENV_DIR/ENVKEY ]; then
   echo $(./envkey-source) > $BP_DIR/export
   echo "EnvKey variables exported to subsequent buildpacks" | indent
   mkdir $BUILD_DIR/.profile.d
-  cat > $BUILD_DIR/.profile.d/envkey.sh << EOF
+  cat > $BUILD_DIR/.profile.d/00-envkey.sh << EOF
 export -p > ./envkey-heroku-runtime-env.sh
 $(cat $BP_DIR/export)
 . ./envkey-heroku-runtime-env.sh


### PR DESCRIPTION
Setting environment variables is critical for other buildpacks (like the Datadog buildpack). 

But scripts in the `profile.d` folder are run in alphabetical order, therefore, any script with a letter between a-e would run before the `envkey.sh` is run, and, therefore, wouldn't have access to the env variables.

This PR changes the name of the `envkey.sh` script to `00-envkey.sh` to ensure it always runs before any other buildpack `profile.d` script.